### PR TITLE
ランダムに統率者カードを送信

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,8 +41,6 @@ func settingInit() error {
 }
 
 func main() {
-	fmt.Printf("Hello, world!!!\n")
-
 	discord, err := discordgo.New()
 	discord.Token = appConfig.DiscordBotToken
 	if err != nil {

--- a/message.go
+++ b/message.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 	"time"
-	
+
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -25,10 +25,12 @@ func checkMessage(s *discordgo.Session, m *discordgo.MessageCreate, c *discordgo
 	}
 
 	switch {
-		case strings.HasPrefix(m.Content, fmt.Sprintf("%s %s", appConfig.BotName, "おはよう")):
-			sendMessage(s, c, fmt.Sprintf("%s おはよう、%s。", createMention(m.Author), m.Author.Username))
-		default :
-			sendRandomMessage(s, c)
+	case strings.HasPrefix(m.Content, fmt.Sprintf("%s %s", appConfig.BotName, "おはよう")):
+		sendMessage(s, c, fmt.Sprintf("%s おはよう、%s。", createMention(m.Author), m.Author.Username))
+	case strings.HasPrefix(strings.ToLower(m.Content), fmt.Sprintf("%s %s", appConfig.BotName, "mtg")):
+		sendRandomCommanderCard(s, c)
+	default:
+		sendRandomMessage(s, c)
 	}
 }
 
@@ -56,7 +58,7 @@ func sendRandomMessage(s *discordgo.Session, c *discordgo.Channel) {
 }
 
 // メンションを作成する
-func createMention(user *discordgo.User) (string) {
+func createMention(user *discordgo.User) string {
 	return fmt.Sprintf("<@%s>", user.ID)
 }
 
@@ -73,16 +75,15 @@ func createRandomMessageList() ([]string, error) {
 
 	// テキスト内の各行の文字列を単一のメッセージとする
 	s := bufio.NewScanner(f)
-    for s.Scan() {
+	for s.Scan() {
 		log.Println(s.Text())
 		msgList = append(msgList, s.Text())
 	}
-	
-    if s.Err() != nil {
-        // non-EOF error.
-        fmt.Println(s.Err())
-    }
+
+	if s.Err() != nil {
+		// non-EOF error.
+		fmt.Println(s.Err())
+	}
 
 	return msgList, nil
 }
-

--- a/sendMtgCard.go
+++ b/sendMtgCard.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/MagicTheGathering/mtg-sdk-go"
+	"github.com/bwmarrin/discordgo"
+)
+
+// ランダムに統率者カードを送信する
+func sendRandomCommanderCard(s *discordgo.Session, c *discordgo.Channel) {
+	cards, err := mtg.NewQuery().Where(mtg.CardGameFormat, "Commander").Where(mtg.CardType, "Creature").Where(mtg.CardSupertypes, "Legendary").Random(1)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for _, card := range cards {
+		sendMessage(s, c, getJapaneseCardImageUrl(card))
+	}
+}
+
+// 日本語のカードを送信
+func getJapaneseCardImageUrl(card *mtg.Card) string {
+	var foreignNames = card.ForeignNames
+
+	// 日本語のカード情報を取得
+	var japaneseCardName mtg.ForeignCardName
+	for _, fn := range foreignNames {
+		if fn.Language == "Japanese" {
+			japaneseCardName = fn
+			fmt.Println(japaneseCardName)
+		}
+	}
+
+	var cardImageUrl string
+	if japaneseCardName.Name != "" {
+		cardImageUrl = createCardImageUrl(japaneseCardName.MultiverseId)
+	} else {
+		// 日本語のカードがない場合、オリジナル(英語)のカードを送信
+		cardImageUrl = card.ImageUrl
+	}
+
+	return cardImageUrl
+}
+
+// カードIDからURL生成
+func createCardImageUrl(id uint) string {
+	return fmt.Sprintf("http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=%d&type=card", id)
+}


### PR DESCRIPTION
- 「mtg」と話しかけるとランダムに取得した伝説のクリーチャーカードのURLを送信
-  日本語のカードがない場合、英語版を送信
- 不要な記述を削除
- 規約に沿った記述に修正